### PR TITLE
Clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,3 @@ letter:
 ```
 $ turt add with_rules username --pattern "digit+symbol+upper" --length 20
 ```
-
-## status
-
-Current major todos:
-
--[] clipboard functionality isn't working on my machine right now
--[] running as a server for networked connections
-


### PR DESCRIPTION
Passwords get copied to the clipboard for a configurable amount of time. The clipboard is restored (with the original string contents) afterwards.